### PR TITLE
Prepare for Laminas

### DIFF
--- a/asset.sh
+++ b/asset.sh
@@ -5,12 +5,6 @@ SCRIPT_PATH="$(cd "$(dirname "$0")" && pwd -P)"
 
 cd $SCRIPT_PATH/asset
 npm install --no-save
-
-# Running each task separately due to concurrency issues when run
-# at once via `gulp`
-gulp images
-gulp icons
-gulp scripts
-gulp styles
+gulp 
 
 perl -pi -e 's/\.[a-z]+"(:)|"|,|^\{\n$|\}/$1/g' ../assets.yml

--- a/asset/gulpfile.js
+++ b/asset/gulpfile.js
@@ -111,6 +111,6 @@ exports.watch = () => {
     watch('js/**/*.js', js);
     watch('sass/**/*.scss', css);
 };
-exports.default = () => {
-    parallel(js, fonts, css, images);
+exports.default = (done) => {
+    parallel(js, fonts, css, images)(done);
 };

--- a/asset/js/component-list.js
+++ b/asset/js/component-list.js
@@ -6,29 +6,7 @@
     }
 
     function prepareComponentList(components) {
-        const componentList = {
-            learn: {
-                label: "Learn ZF",
-                choices: []
-            },
-            middleware: {
-                label: "Expressive and PSR-15 Middleware",
-                choices: []
-            },
-            mvc: {
-                label: "MVC Framework",
-                choices: []
-            },
-            components: {
-                label: "Components",
-                choices: []
-            },
-            projects: {
-                label: "Tooling and Composer Plugins",
-                choices: []
-            }
-        };
-        let uncategorized = [];
+        let componentList = [];
 
         // eslint-disable-next-line no-use-before-define
         const matchActive = new RegExp('\/' + siteName + '(\/|$)');
@@ -46,9 +24,7 @@
                 }
             };
 
-            componentList.hasOwnProperty(component.group)
-                ? componentList[component.group].choices.push(choice)
-                : uncategorized.push(choice);
+            componentList.push(choice);
         });
 
         // Initialize the Choices selector using the component selector as its element
@@ -65,7 +41,7 @@
             });
 
             choices.setChoices(
-                Array.prototype.concat.apply(Object.values(componentList), uncategorized),
+                componentList,
                 'value',
                 'label',
                 true
@@ -186,7 +162,7 @@
     window.addEventListener('load', function () {
         const request = new XMLHttpRequest();
         request.onreadystatechange = parseComponentList;
-        request.open('GET', '//docs.zendframework.com/zf-mkdoc-theme/scripts/zf-component-list.json');
+        request.open('GET', '/component-list.json');
         request.send();
     });
 }

--- a/assets.yml
+++ b/assets.yml
@@ -1,3 +1,1 @@
-{
-  "styles.css": "styles-5de3bb4793.css"
-}
+  styles: styles-5de3bb4793.css

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@
 # and run from the project root.
 #
 # @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
-# @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright Copyright (c) 2019 Laminas Project (https://getlaminas.org)
 
 SCRIPT_PATH="$(cd "$(dirname "$0")" && pwd -P)"
 
@@ -43,9 +43,9 @@ echo "Building documentation in ${DOC_DIR}"
 ${SCRIPT_PATH}/update_mkdocs_yml.py ${SITE_URL} ${DOCS_DIR}
 
 # Preserve files if necessary (as mkdocs build --clean removes all files)
-if [ -e .zf-mkdoc-theme-preserve ]; then
+if [ -e .laminas-mkdoc-theme-preserve ]; then
     mkdir .preserve
-    for PRESERVE in $(cat .zf-mkdoc-theme-preserve); do
+    for PRESERVE in $(cat .laminas-mkdoc-theme-preserve); do
         cp ${DOC_DIR}/html/${PRESERVE} .preserve/
     done
 fi
@@ -60,8 +60,8 @@ mkdocs build --clean
 mv mkdocs.yml.orig mkdocs.yml
 
 # Restore files if necessary
-if [ -e .zf-mkdoc-theme-preserve ]; then
-    for PRESERVE in $(cat .zf-mkdoc-theme-preserve); do
+if [ -e .laminas-mkdoc-theme-preserve ]; then
+    for PRESERVE in $(cat .laminaszf-mkdoc-theme-preserve); do
         mv .preserve/${PRESERVE} ${DOC_DIR}/html/${PRESERVE}
     done
     rm -Rf ./preserve
@@ -84,7 +84,7 @@ echo "Fixing fenced code blocks"
 php ${SCRIPT_PATH}/fenced_code.php ${DOC_DIR}
 
 # Replace landing page content
-if [ -e .zf-mkdoc-theme-landing ]; then
+if [ -e .laminas-mkdoc-theme-landing ]; then
     echo "Replacing landing page content"
     php ${SCRIPT_PATH}/swap_index.php ${DOC_DIR}
 fi

--- a/theme-installer.sh
+++ b/theme-installer.sh
@@ -5,7 +5,7 @@
 #
 # - Installs mkdocs under the current user.
 # - Installs pymdown-extensions under the current user.
-# - If the zf-mkdoc-theme is not present under the current directory, downloads
+# - If the documentation-theme is not present under the current directory, downloads
 #   and installs the latest tarball.
 #
 # In order to work, it needs the following environment variables defined:
@@ -14,7 +14,7 @@
 # into the documentation auto-deployment workflow.
 #
 # @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
-# @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+# @copyright Copyright (c) 2019 Laminas Project (https://getlaminas.org)
 
 SCRIPT_PATH="$(pwd)"
 
@@ -23,16 +23,19 @@ pip install --user mkdocs
 pip install --user pymdown-extensions
 pip install --user markdown-fenced-code-tabs
 
-# Conditionally install zf-mkdoc-theme.
-if [[ ! -d "zf-mkdoc-theme/theme" ]];then
-    echo "Downloading zf-mkdoc-theme..." ;
-    mkdir -p zf-mkdoc-theme ;
-    curl -s -L https://github.com/zendframework/zf-mkdoc-theme/releases/latest | egrep -o '/zendframework/zf-mkdoc-theme/archive/[0-9]*\.[0-9]*\.[0-9]*\.tar\.gz' | head -n1 | wget -O zf-mkdoc-theme.tgz --base=https://github.com/ -i - ;
+# Conditionally install documentation-theme.
+if [[ ! -d "laminas-mkdoc-theme/theme" ]];then
+    echo "Downloading documentation-theme..." ;
+    mkdir -p laminas-mkdoc-theme ;
+    curl -s -L https://github.com/laminas/documentation-theme/releases/latest |
+        egrep -o '/laminas/documentation-theme/archive/[0-9]*\.[0-9]*\.[0-9]*\.tar\.gz' |
+        head -n1 |
+        wget -O documentation-theme.tgz --base=https://github.com/ -i - ;
     (
-        cd zf-mkdoc-theme ;
-        tar xzf ../zf-mkdoc-theme.tgz --strip-components=1 ;
+        cd laminas-mkdoc-theme ;
+        tar xzf ../documentation-theme.tgz --strip-components=1 ;
     );
-    echo "Finished downloading and installing zf-mkdoc-theme" ;
+    echo "Finished downloading and installing documentation-theme" ;
 fi
 
 exit 0;

--- a/theme/main.html
+++ b/theme/main.html
@@ -12,11 +12,11 @@
     <meta name="description" content="{{ config.site_description|striptags }}">{% endif %} {% if config.site_author %}
     <meta name="author" content="{{ config.site_author }}">{% endif %} {% if page.canonical_url %}
     <link rel="canonical" href="{{ page.canonical_url }}">{% endif %}
-    <link rel="shortcut icon" href="{{ 'img/trademark-laminas-foundation-rgb.svg'|url }}">
+    <link rel="shortcut icon" href="{{ '/img/trademark-laminas-foundation-rgb.svg'|url }}">
 
     <title>{% if page.title and page.title != 'Home' %}{{ page.title }} - {% endif %}{{ config.site_name }} - Laminas Docs</title>
 
-    <link rel="stylesheet" href="{{ ('css/styles.css')|url }}">
+    <link rel="stylesheet" href="{{ ('/css/styles.css')|url }}">
     {%- for path in extra_css %}
         <link href="{{ path }}" rel="stylesheet">
     {%- endfor %}
@@ -57,7 +57,7 @@
             project  = "{{ config.extra.project|lower|replace(' ', '-') }}",
             siteName = '{{ config.site_name }}';
     </script>
-    <script src="{{ ('js/scripts.js')|url }}"></script>
+    <script src="{{ ('/js/scripts.js')|url }}"></script>
 
     {# Search modal #}
     {% include "partials/search-modal.html" %}

--- a/theme/partials/footer.html
+++ b/theme/partials/footer.html
@@ -26,25 +26,22 @@
                 <h4 class="footer__headline">Support</h4>
                 <ul class="support__list">
                     <li class="support__list-item">
-                        <a href="https://discourse.zendframework.com" class="support__link" title="Forum"><i class="fa fa-comments"></i></a>
+                        <a href="https://discourse.laminas.dev" class="support__link" title="Forum"><i class="fa fa-comments"></i></a>
                     </li>
                     <li class="support__list-item">
-                        <a href="https://zendframework-slack.herokuapp.com" class="support__link" title="Chat"><i class="fa fa-slack"></i></a>
+                        <a href="https://laminas.dev/chat" class="support__link" title="Chat"><i class="fa fa-slack"></i></a>
                     </li>
                     <li class="support__list-item">
-                        <a href="https://github.com/zendframework" class="support__link" title="Github"><i class="fa fa-github"></i></a>
+                        <a href="https://github.com/laminas" class="support__link" title="Github"><i class="fa fa-github"></i></a>
                     </li>
                     <li class="support__list-item">
-                        <a href="https://twitter.com/zfdevteam" class="support__link" title="Twitter"><i class="fa fa-twitter"></i></a>
+                        <a href="https://twitter.com/getlaminas" class="support__link" title="Twitter"><i class="fa fa-twitter"></i></a>
                     </li>
                     <li class="support__list-item">
-                        <a href="https://tinyletter.com/mwopzend" class="support__link" title="Newsletter"><i class="fa fa-envelope"></i></a>
+                        <a href="https://getlaminas.org/blog/feed-rss.xml" class="support__link" title="Blog feed"><i class="fa fa-rss"></i></a>
                     </li>
                     <li class="support__list-item">
-                        <a href="https://framework.zend.com/blog/feed-rss.xml" class="support__link" title="Blog feed"><i class="fa fa-rss"></i></a>
-                    </li>
-                    <li class="support__list-item">
-                        <a href="https://framework.zend.com/security/feed" class="support__link" title="Security feed"><i class="fa fa-rss-square"></i></a>
+                        <a href="https://getlaminas.org/security/feed" class="support__link" title="Security feed"><i class="fa fa-rss-square"></i></a>
                     </li>
                 </ul>
             </div>
@@ -53,7 +50,8 @@
             <div class="col-md-3">
                 <h4 class="footer__headline">License</h4>
                 <p>
-                    Code licensed under <a href="https://github.com/zendframework/{{ config.site_name }}/blob/master/LICENSE.md">BSD 3-Clause</a>.
+                    Code licensed under <a
+                        href="{{config.repo_url }}/blob/master/LICENSE.md">BSD 3-Clause</a>.
                 </p>
             </div>
 
@@ -62,7 +60,7 @@
                 <h4 class="footer__headline">Copyright</h4>
                 <p>
                     <!--Built with love by the Laminas team with the help of our
-                    <a href="https://github.com/zendframework/{{ config.site_name }}/graphs/contributors">contributors</a>.<br>-->
+                    <a href="{{ config.repo_url }}/graphs/contributors">contributors</a>.<br>-->
                     &copy; 2019-{{ build_date_utc.strftime('%Y') }} by <a href="https://getlaminas.org/">The Laminas Project</a>.
                 </p>
             </div>

--- a/update_mkdocs_yml.py
+++ b/update_mkdocs_yml.py
@@ -37,13 +37,13 @@ mkdocs["markdown_extensions"] = [
 
 mkdocs["theme"] = {
         "name": None,
-        "custom_dir": "zf-mkdoc-theme/theme",
+        "custom_dir": "laminas-mkdoc-theme/theme",
         "static_templates": [
             "404.html"
         ]
     }
 
-with open("zf-mkdoc-theme/assets.yml") as f:
+with open("laminas-mkdoc-theme/assets.yml") as f:
     assets = yaml.load(f, Loader=yaml.SafeLoader)
 
 if "extra" not in mkdocs.keys():


### PR DESCRIPTION
This patch does several things:

- The repository transfer tool is rewriting "zf-mkdoc-theme" to "laminas-mkdoc-theme" everywhere. This affects things like the `.gitignore` rules, the overrides for the theme, etc. As such, I've updated all references to zf-mkdoc-theme to read laminas-mkdoc-theme.  **HOWEVER**, I am planning on having the repo be named 'documentation-theme' as you have done here already. I've accounted for both in the installer and build scripts.

- I've updated social media links, license links, etc. to point to the new canonical locations.

- I've updated the component-list.js as follows:
  - It looks for the file "component-list.json" in the web root of the current domain.
  - It no longer worries about component groups when building the list of components; they're grouped by project already.

- I've updated `asset/gulpfile.js` to work under modern gulp versions, which expect tasks to run asynchronously. You can now run `gulp` without any targets. This allowed me to simplfiy the `assets.sh` script as well.

- Update updated the theme to use js, css, and images from the documentation root. Essentially, we can build them from this repo, and import them into the github pages repo representing the domain.

I've tested locally using a few components, and it seems to be working great with these changes!